### PR TITLE
Remove original Monero DNS nodes

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -127,7 +127,9 @@ namespace nodetool
     virtual bool unblock_host(const epee::net_utils::network_address &address);
     virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
   private:
-    const std::vector<std::string> m_seed_nodes_list = {};
+    const std::vector<std::string> m_seed_nodes_list = {
+      // FIXME (seed-nodes)
+    };
 
     bool islimitup=false;
     bool islimitdown=false;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -127,12 +127,7 @@ namespace nodetool
     virtual bool unblock_host(const epee::net_utils::network_address &address);
     virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
   private:
-    const std::vector<std::string> m_seed_nodes_list =
-    { "seeds.moneroseeds.se"
-    , "seeds.moneroseeds.ae.org"
-    , "seeds.moneroseeds.ch"
-    , "seeds.moneroseeds.li"
-    };
+    const std::vector<std::string> m_seed_nodes_list = {};
 
     bool islimitup=false;
     bool islimitdown=false;


### PR DESCRIPTION
Original Monero DNS nodes should be removed from list. Later Snowflake ones should be provided instead